### PR TITLE
SC-2810: handle multiple collateral types better

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,20 +35,21 @@ After following the setup procedure below, this keeper works out of the box unde
     - `ETHGASSTATION_API_KEY`: eth gas station API KEY, can be applied for at https://data.concourseopen.com/
     - `GASPRICE_MULTIPLIER`: dynamic gas multiplier (e.g. if 2.0 then will use 2 * base)
     - `FIRST_BLOCK_TO_CHECK`: Recommendation under introduction section
-    - `FLIP_ACCOUNT_ADDRESS`: address to use for bidding
+    - `FLIP_ETH_A_ACCOUNT_ADDRESS` | `FLIP_BAT_A_ACCOUNT_ADDRESS` | `FLIP_USDC_A_ACCOUNT_ADDRESS` | `FLIP_WBTC_A_ACCOUNT_ADDRESS`: address to use for bidding
     - `FLIP_ETH_A_ACCOUNT_KEY` | `FLIP_BAT_A_ACCOUNT_KEY` | `FLIP_USDC_A_ACCOUNT_KEY` | `FLIP_WBTC_A_ACCOUNT_KEY`: account key format of `key_file=/opt/keeper/secrets/keystore.json,pass_file=/opt/keeper/secrets/password.txt`
     Note: path to file should always be `/opt/keeper/secrets/` followed by the name of file you create under secrets directory
     Ex: if you put `keystore-flip-a.json` and `password-flip-a.txt` under `secrets` directory then var should be configured as
-    `FLIP_ETH_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-a.json,pass_file=/opt/keeper/secrets/password-flip-a.txt'`
+    `FLIP_ETH_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-eth-a.json,pass_file=/opt/keeper/secrets/password-flip-eth-a.txt'`
     or
-    `FLIP_BAT_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-a.json,pass_file=/opt/keeper/secrets/password-flip-a.txt'`
+    `FLIP_BAT_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-bat-a.json,pass_file=/opt/keeper/secrets/password-flip-bat-a.txt'`
     or
-    `FLIP_USDC_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-a.json,pass_file=/opt/keeper/secrets/password-flip-a.txt'`
+    `FLIP_USDC_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-usdc-a.json,pass_file=/opt/keeper/secrets/password-flip-usdc-a.txt'`
     or
-    `FLIP_WBTC_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-a.json,pass_file=/opt/keeper/secrets/password-flip-a.txt'`
+    `FLIP_WBTC_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-wbtc-a.json,pass_file=/opt/keeper/secrets/password-flip-wbtc-a.txt'`
     - `FLIP_DAI_IN_VAT`: Amount of Dai in Vat (Internal Dai Balance); important that this is higher than your largest estimated bid amount
-    - `FLIP_MINIMUM_AUCTION_ID_TO_CHECK`: Recommendation under introduction section
-    - `FLIP_ETH_DISCOUNT` | `FLIP_BAT_DISCOUNT` | `FLIP_USDC_DISCOUNT` | `FLIP_WBTC_DISCOUNT`: Discount from ETH's or BAT's or USDC's FMV or WBTC's FMV, which will be used as the bid price
+    - `FLIP_ETH_A_DAI_IN_VAT` | `FLIP_BAT_A_DAI_IN_VAT` | `FLIP_USDC_A_DAI_IN_VAT` | `FLIP_WBTC_A_DAI_IN_VAT`: Amount of Dai in Vat per collateral type
+    - `FLIP_MINIMUM_ETH_A_AUCTION_ID_TO_CHECK` | `FLIP_MINIMUM_BAT_A_AUCTION_ID_TO_CHECK` | `FLIP_MINIMUM_USDC_A_AUCTION_ID_TO_CHECK` | `FLIP_MINIMUM_WBTC_A_AUCTION_ID_TO_CHECK`: Recommendation under introduction section
+    - `FLIP_ETH_A_DISCOUNT` | `FLIP_BAT_A_DISCOUNT` | `FLIP_USDC_A_DISCOUNT` | `FLIP_WBTC_A_DISCOUNT`: Discount from ETH's or BAT's or USDC's FMV or WBTC's FMV, which will be used as the bid price
 
 ### Setup flop keeper
 

--- a/env/environment.sh
+++ b/env/environment.sh
@@ -16,52 +16,48 @@ GASPRICE_MULTIPLIER=1.6
 # ethgasstation.info for dynamic gas, otherwise we will simply check the node.
 ETHGASSTATION_API_KEY=MY_ETH_GASSTATION_KEY
 FULL_PATH_TO_KEEPER_DIRECTORY=/opt/keeper/auction-keeper
-FIRST_BLOCK_TO_CHECK=14764534
+FIRST_BLOCK_TO_CHECK=10142593
+DAI_IN_VAT=10000
 
 ###### FLIP-ETH-A Config ######
-FLIP_ACCOUNT_ADDRESS=0x40418bxxxxxx
-FLIP_ETH_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-a.json,pass_file=/opt/keeper/secrets/password-flip-a.txt'
-FLIP_DAI_IN_VAT=1000
-FLIP_ILK=ETH-A
-FLIP_MINIMUM_AUCTION_ID_TO_CHECK=1800
-
+FLIP_ETH_A_ACCOUNT_ADDRESS='0x40418bxxxxxx'
+FLIP_ETH_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-eth-a.json,pass_file=/opt/keeper/secrets/password-flip-eth-a.txt'
+FLIP_ETH_A_DAI_IN_VAT=${DAI_IN_VAT}
+FLIP_ILK_ETH_A=ETH-A
+FLIP_MINIMUM_ETH_A_AUCTION_ID_TO_CHECK=4914
 FLIP_ETH_URL="https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd"
 FLIP_ETH_DISCOUNT=0.25 # e.g. 0.25 = 25% discount from FMV
 
 ###### FLIP-BAT-A Config ######
-FLIP_ACCOUNT_ADDRESS=0x40418bxxxxxx
-FLIP_BAT_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-a.json,pass_file=/opt/keeper/secrets/password-flip-a.txt'
-FLIP_DAI_IN_VAT=1000
-FLIP_ILK_BAT=BAT-A
-FLIP_MINIMUM_AUCTION_ID_TO_CHECK=1800
-
+FLIP_BAT_A_ACCOUNT_ADDRESS='0x40418bxxxxxx'
+FLIP_BAT_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-bat-a.json,pass_file=/opt/keeper/secrets/password-flip-bat-a.txt'
+FLIP_BAT_A_DAI_IN_VAT=${DAI_IN_VAT}
+FLIP_ILK_BAT_A=BAT-A
+FLIP_MINIMUM_BAT_A_AUCTION_ID_TO_CHECK=471
 FLIP_BAT_URL="https://api.coingecko.com/api/v3/simple/price?ids=basic-attention-token&vs_currencies=usd"
 FLIP_BAT_DISCOUNT=0.25 # e.g. 0.25 = 25% discount from FMV
 
 ###### FLIP-USDC-A Config ######
-FLIP_ACCOUNT_ADDRESS=0x40418bxxxxxx
-FLIP_USDC_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-a.json,pass_file=/opt/keeper/secrets/password-flip-a.txt'
-FLIP_DAI_IN_VAT=1000
-FLIP_ILK_USDC=USDC-A
-FLIP_MINIMUM_AUCTION_ID_TO_CHECK=1800
-
+FLIP_USDC_A_ACCOUNT_ADDRESS='0x40418bxxxxxx'
+FLIP_USDC_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-usdc-a.json,pass_file=/opt/keeper/secrets/password-flip-usdc-a.txt'
+FLIP_USDC_A_DAI_IN_VAT=${DAI_IN_VAT}
+FLIP_ILK_USDC_A=USDC-A
+FLIP_MINIMUM_USDC_A_AUCTION_ID_TO_CHECK=0
 FLIP_USDC_URL="https://api.coingecko.com/api/v3/simple/price?ids=usd-coin&vs_currencies=usd"
 FLIP_USDC_DISCOUNT=0.25 # e.g. 0.25 = 25% discount from FMV
 
 ###### FLIP-WBTC-A Config ######
-FLIP_ACCOUNT_ADDRESS=0x40418bxxxxxx
-FLIP_WBTC_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-a.json,pass_file=/opt/keeper/secrets/password-flip-a.txt'
-FLIP_DAI_IN_VAT=1000
-FLIP_ILK_WBTC=WBTC-A
-FLIP_MINIMUM_WBTC_AUCTION_ID_TO_CHECK=0
-
+FLIP_WBTC_A_ACCOUNT_ADDRESS='0x40418bxxxxxx'
+FLIP_WBTC_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-wbtc-a.json,pass_file=/opt/keeper/secrets/password-flip-wbtc-a.txt'
+FLIP_WBTC_A_DAI_IN_VAT=${DAI_IN_VAT}
+FLIP_ILK_WBTC_A=WBTC-A
+FLIP_MINIMUM_WBTC_A_AUCTION_ID_TO_CHECK=2
 FLIP_WBTC_URL="https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd"
 FLIP_WBTC_DISCOUNT=0.25 # e.g. 0.25 = 25% discount from FMV
 
 ###### FLOP Config ######
-FLOP_ACCOUNT_ADDRESS=0x40418bxxxxxx
+FLOP_ACCOUNT_ADDRESS='0x40418bxxxxxx'
 FLOP_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flop.json,pass_file=/opt/keeper/secrets/password-flop.txt'
-FLOP_DAI_IN_VAT=5000000
-
+FLOP_DAI_IN_VAT=${DAI_IN_VAT}
 FLOP_MKR_URL="https://api.coingecko.com/api/v3/simple/price?ids=maker&vs_currencies=usd"
 FLOP_MKR_DISCOUNT=0.25 # e.g. 0.25 = 25% discount from FMV

--- a/flip/bat-a/flip-bat-a.sh
+++ b/flip/bat-a/flip-bat-a.sh
@@ -10,15 +10,15 @@ MODEL=$1
 
 ${FULL_PATH_TO_KEEPER_DIRECTORY}/bin/auction-keeper \
     --rpc-host ${SERVER_ETH_RPC_HOST:?} \
-    --rpc-timeout 30 \
-    --eth-from ${FLIP_ACCOUNT_ADDRESS?:} \
+    --rpc-timeout 300 \
+    --eth-from ${FLIP_BAT_A_ACCOUNT_ADDRESS?:} \
     --eth-key ${FLIP_BAT_A_ACCOUNT_KEY?:} \
     --type flip \
     --max-auctions 100 \
     $(dynamic_gas_params) \
-    --vat-dai-target ${FLIP_DAI_IN_VAT} \
+    --vat-dai-target ${FLIP_BAT_A_DAI_IN_VAT} \
     --from-block ${FIRST_BLOCK_TO_CHECK} \
-    --ilk ${FLIP_ILK_BAT} \
+    --ilk ${FLIP_ILK_BAT_A} \
     --bid-only \
-    --min-auction ${FLIP_MINIMUM_AUCTION_ID_TO_CHECK} \
+    --min-auction ${FLIP_MINIMUM_BAT_A_AUCTION_ID_TO_CHECK} \
     --model ${dir}/${MODEL}

--- a/flip/eth-a/flip-eth-a.sh
+++ b/flip/eth-a/flip-eth-a.sh
@@ -10,15 +10,15 @@ MODEL=$1
 
 ${FULL_PATH_TO_KEEPER_DIRECTORY}/bin/auction-keeper \
     --rpc-host ${SERVER_ETH_RPC_HOST:?} \
-    --rpc-timeout 30 \
-    --eth-from ${FLIP_ACCOUNT_ADDRESS?:} \
+    --rpc-timeout 300 \
+    --eth-from ${FLIP_ETH_A_ACCOUNT_ADDRESS?:} \
     --eth-key ${FLIP_ETH_A_ACCOUNT_KEY?:} \
     --type flip \
     --max-auctions 100 \
     $(dynamic_gas_params) \
-    --vat-dai-target ${FLIP_DAI_IN_VAT} \
+    --vat-dai-target ${FLIP_ETH_A_DAI_IN_VAT} \
     --from-block ${FIRST_BLOCK_TO_CHECK} \
+    --ilk ${FLIP_ILK_ETH_A} \
     --bid-only \
-    --ilk ${FLIP_ILK} \
-    --min-auction ${FLIP_MINIMUM_AUCTION_ID_TO_CHECK} \
+    --min-auction ${FLIP_MINIMUM_ETH_A_AUCTION_ID_TO_CHECK} \
     --model ${dir}/${MODEL}

--- a/flip/usdc-a/flip-usdc-a.sh
+++ b/flip/usdc-a/flip-usdc-a.sh
@@ -10,15 +10,15 @@ MODEL=$1
 
 ${FULL_PATH_TO_KEEPER_DIRECTORY}/bin/auction-keeper \
     --rpc-host ${SERVER_ETH_RPC_HOST:?} \
-    --rpc-timeout 30 \
-    --eth-from ${FLIP_ACCOUNT_ADDRESS?:} \
+    --rpc-timeout 300 \
+    --eth-from ${FLIP_USDC_A_ACCOUNT_ADDRESS?:} \
     --eth-key ${FLIP_USDC_A_ACCOUNT_KEY?:} \
     --type flip \
     --max-auctions 100 \
     $(dynamic_gas_params) \
-    --vat-dai-target ${FLIP_DAI_IN_VAT} \
+    --vat-dai-target ${FLIP_USDC_A_DAI_IN_VAT} \
     --from-block ${FIRST_BLOCK_TO_CHECK} \
-    --ilk ${FLIP_ILK_USDC} \
+    --ilk ${FLIP_ILK_USDC_A} \
     --bid-only \
-    --min-auction ${FLIP_MINIMUM_AUCTION_ID_TO_CHECK} \
+    --min-auction ${FLIP_MINIMUM_USDC_A_AUCTION_ID_TO_CHECK} \
     --model ${dir}/${MODEL}

--- a/flip/wbtc-a/flip-wbtc-a.sh
+++ b/flip/wbtc-a/flip-wbtc-a.sh
@@ -10,15 +10,15 @@ MODEL=$1
 
 ${FULL_PATH_TO_KEEPER_DIRECTORY}/bin/auction-keeper \
     --rpc-host ${SERVER_ETH_RPC_HOST:?} \
-    --rpc-timeout 30 \
-    --eth-from ${FLIP_ACCOUNT_ADDRESS?:} \
+    --rpc-timeout 300 \
+    --eth-from ${FLIP_WBTC_A_ACCOUNT_ADDRESS?:} \
     --eth-key ${FLIP_WBTC_A_ACCOUNT_KEY?:} \
     --type flip \
     --max-auctions 100 \
     $(dynamic_gas_params) \
-    --vat-dai-target ${FLIP_DAI_IN_VAT} \
+    --vat-dai-target ${FLIP_WBTC_A_DAI_IN_VAT} \
     --from-block ${FIRST_BLOCK_TO_CHECK} \
-    --ilk ${FLIP_ILK_WBTC} \
+    --ilk ${FLIP_ILK_WBTC_A} \
     --bid-only \
-    --min-auction ${FLIP_MINIMUM_WBTC_AUCTION_ID_TO_CHECK} \
+    --min-auction ${FLIP_MINIMUM_WBTC_A_AUCTION_ID_TO_CHECK} \
     --model ${dir}/${MODEL}


### PR DESCRIPTION
This is in anticipation of adding many more collateral types, and especially ones with `A` and `B` variants.  This also adjusts min values, the block height, and rpc timeout.