### PR TITLE
SC-2812: adds TUSD-A collateral

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,24 +19,24 @@ https://docs.docker.com/compose/install/
 ### Setup flip keepers
 
 After following the setup procedure below, this keeper works out of the box under the following configuration:
-- Participates in up to 100 active ETH-A or BAT-A or USDC-A or WBTC-A Flip auctions; it does not start new ones
+- Participates in up to 100 active ETH-A or BAT-A or USDC-A or WBTC-A or TUSD-A or Flip auctions; it does not start new ones
 - Begins scan at a prescribed auction id - we recommend starting at:
   - `mainnet` - 4500 for `ETH`, 500 for `BAT` and 0 for `WBTC`
   - `kovan` - 1800
 - Looks for Vaults (i.e. `urns`) at a supplied block height - we recommend starting at the block that `Vat` was deployed:
   - `mainnet` - 8928152
   - `kovan 1.0.2` - 14764534
-- Uses a pricing model that tracks the price of ETH | BAT | USDC | WBTC via a public API and applies a `DISCOUNT` before participating
-- All logs from the keeper are saved and appended to a single file (`auction-keeper-flip-ETH-A.log` or `auction-keeper-flip-BAT-A.log` or `auction-keeper-flip-USDC-A.log` or `auction-keeper-flip-WBTC-A.log`)
+- Uses a pricing model that tracks the price of ETH | BAT | USDC | WBTC | TUSD via a public API and applies a `DISCOUNT` before participating
+- All logs from the keeper are saved and appended to a single file (`auction-keeper-flip-ETH-A.log` or `auction-keeper-flip-BAT-A.log` or `auction-keeper-flip-USDC-A.log` or `auction-keeper-flip-WBTC-A.log` or `auction-keeper-flip-TUSD-A.log`)
 
-- Place unlocked keystore and password file for account address under `secrets` directory. The names of the keystore and password files will need to be updated in the `FLIP_ETH_A_ACCOUNT_KEY` | `FLIP_BAT_A_ACCOUNT_KEY` | `FLIP_USDC_A_ACCOUNT_KEY` | `FLIP_WBTC_A_ACCOUNT_KEY` in the env.
+- Place unlocked keystore and password file for account address under `secrets` directory. The names of the keystore and password files will need to be updated in the `FLIP_ETH_A_ACCOUNT_KEY` | `FLIP_BAT_A_ACCOUNT_KEY` | `FLIP_USDC_A_ACCOUNT_KEY` | `FLIP_WBTC_A_ACCOUNT_KEY` | `FLIP_TUSD_A_ACCOUNT_KEY` in the env.
 - Configure following variables in `env/environment.sh` file:
     - `SERVER_ETH_RPC_HOST`: URL to ETH Parity node (containing port if case) e.g. http://localhost:8545
     - `ETHGASSTATION_API_KEY`: eth gas station API KEY, can be applied for at https://data.concourseopen.com/
     - `GASPRICE_MULTIPLIER`: dynamic gas multiplier (e.g. if 2.0 then will use 2 * base)
     - `FIRST_BLOCK_TO_CHECK`: Recommendation under introduction section
-    - `FLIP_ETH_A_ACCOUNT_ADDRESS` | `FLIP_BAT_A_ACCOUNT_ADDRESS` | `FLIP_USDC_A_ACCOUNT_ADDRESS` | `FLIP_WBTC_A_ACCOUNT_ADDRESS`: address to use for bidding
-    - `FLIP_ETH_A_ACCOUNT_KEY` | `FLIP_BAT_A_ACCOUNT_KEY` | `FLIP_USDC_A_ACCOUNT_KEY` | `FLIP_WBTC_A_ACCOUNT_KEY`: account key format of `key_file=/opt/keeper/secrets/keystore.json,pass_file=/opt/keeper/secrets/password.txt`
+    - `FLIP_ETH_A_ACCOUNT_ADDRESS` | `FLIP_BAT_A_ACCOUNT_ADDRESS` | `FLIP_USDC_A_ACCOUNT_ADDRESS` | `FLIP_WBTC_A_ACCOUNT_ADDRESS` | `FLIP_TUSD_A_ACCOUNT_ADDRESS`: address to use for bidding
+    - `FLIP_ETH_A_ACCOUNT_KEY` | `FLIP_BAT_A_ACCOUNT_KEY` | `FLIP_USDC_A_ACCOUNT_KEY` | `FLIP_WBTC_A_ACCOUNT_KEY` | `FLIP_TUSD_A_ACCOUNT_KEY`: account key format of `key_file=/opt/keeper/secrets/keystore.json,pass_file=/opt/keeper/secrets/password.txt`
     Note: path to file should always be `/opt/keeper/secrets/` followed by the name of file you create under secrets directory
     Ex: if you put `keystore-flip-a.json` and `password-flip-a.txt` under `secrets` directory then var should be configured as
     `FLIP_ETH_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-eth-a.json,pass_file=/opt/keeper/secrets/password-flip-eth-a.txt'`
@@ -46,10 +46,12 @@ After following the setup procedure below, this keeper works out of the box unde
     `FLIP_USDC_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-usdc-a.json,pass_file=/opt/keeper/secrets/password-flip-usdc-a.txt'`
     or
     `FLIP_WBTC_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-wbtc-a.json,pass_file=/opt/keeper/secrets/password-flip-wbtc-a.txt'`
+    or
+    `FLIP_TUSD_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-tusd-a.json,pass_file=/opt/keeper/secrets/password-flip-tusd-a.txt'`
     - `FLIP_DAI_IN_VAT`: Amount of Dai in Vat (Internal Dai Balance); important that this is higher than your largest estimated bid amount
-    - `FLIP_ETH_A_DAI_IN_VAT` | `FLIP_BAT_A_DAI_IN_VAT` | `FLIP_USDC_A_DAI_IN_VAT` | `FLIP_WBTC_A_DAI_IN_VAT`: Amount of Dai in Vat per collateral type
-    - `FLIP_MINIMUM_ETH_A_AUCTION_ID_TO_CHECK` | `FLIP_MINIMUM_BAT_A_AUCTION_ID_TO_CHECK` | `FLIP_MINIMUM_USDC_A_AUCTION_ID_TO_CHECK` | `FLIP_MINIMUM_WBTC_A_AUCTION_ID_TO_CHECK`: Recommendation under introduction section
-    - `FLIP_ETH_A_DISCOUNT` | `FLIP_BAT_A_DISCOUNT` | `FLIP_USDC_A_DISCOUNT` | `FLIP_WBTC_A_DISCOUNT`: Discount from ETH's or BAT's or USDC's FMV or WBTC's FMV, which will be used as the bid price
+    - `FLIP_ETH_A_DAI_IN_VAT` | `FLIP_BAT_A_DAI_IN_VAT` | `FLIP_USDC_A_DAI_IN_VAT` | `FLIP_WBTC_A_DAI_IN_VAT` | `FLIP_TUSD_A_DAI_IN_VAT`: Amount of Dai in Vat per collateral type
+    - `FLIP_MINIMUM_ETH_A_AUCTION_ID_TO_CHECK` | `FLIP_MINIMUM_BAT_A_AUCTION_ID_TO_CHECK` | `FLIP_MINIMUM_USDC_A_AUCTION_ID_TO_CHECK` | `FLIP_MINIMUM_WBTC_A_AUCTION_ID_TO_CHECK` | `FLIP_MINIMUM_TUSD_A_AUCTION_ID_TO_CHECK`: Recommendation under introduction section
+    - `FLIP_ETH_A_DISCOUNT` | `FLIP_BAT_A_DISCOUNT` | `FLIP_USDC_A_DISCOUNT` | `FLIP_WBTC_A_DISCOUNT` | `FLIP_TUSD_A_DISCOUNT`: Discount from ETH's or BAT's or USDC's FMV or WBTC's FMV, which will be used as the bid price
 
 ### Setup flop keeper
 
@@ -80,6 +82,9 @@ flip-usdc-a keeper
 
 flip-wbtc-a keeper
 `./start-keeper.sh flip-wbtc-a | tee -a -i auction-keeper-flip-WBTC-A.log`
+
+flip-tusd-a keeper
+`./start-keeper.sh flip-tusd-a | tee -a -i auction-keeper-flip-TSUD-A.log`
 
 flop keeper
 `./start-keeper.sh flop | tee -a -i auction-keeper-flop.log`

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ flip-wbtc-a keeper
 `./start-keeper.sh flip-wbtc-a | tee -a -i auction-keeper-flip-WBTC-A.log`
 
 flip-tusd-a keeper
-`./start-keeper.sh flip-tusd-a | tee -a -i auction-keeper-flip-TSUD-A.log`
+`./start-keeper.sh flip-tusd-a | tee -a -i auction-keeper-flip-TUSD-A.log`
 
 flop keeper
 `./start-keeper.sh flop | tee -a -i auction-keeper-flop.log`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,21 @@ services:
         max-size: "100m"
         max-file: "10"
     command: ./flip-wbtc-a.sh model-wbtc.sh
+  flip-tusd-a:
+    build: .
+    image: makerdao/auction-keeper
+    container_name: flip-tusd-a
+    working_dir: /opt/keeper/flip-tusd-a/
+    volumes:
+      - $PWD/secrets:/opt/keeper/secrets
+      - $PWD/env/:/opt/keeper/env/
+      - $PWD/flip/tusd-a/:/opt/keeper/flip-tusd-a/
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100m"
+        max-file: "10"
+    command: ./flip-tusd-a.sh model-tusd.sh
   flop:
     build: .
     image: makerdao/auction-keeper

--- a/env/environment.sh
+++ b/env/environment.sh
@@ -55,6 +55,15 @@ FLIP_MINIMUM_WBTC_A_AUCTION_ID_TO_CHECK=2
 FLIP_WBTC_URL="https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd"
 FLIP_WBTC_DISCOUNT=0.25 # e.g. 0.25 = 25% discount from FMV
 
+###### FLIP-TUSD-A Config ######
+FLIP_TUSD_A_ACCOUNT_ADDRESS='0x40418bxxxxxx'
+FLIP_TUSD_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-tusd-a.json,pass_file=/opt/keeper/secrets/password-flip-tusd-a.txt'
+FLIP_TUSD_A_DAI_IN_VAT=${DAI_IN_VAT}
+FLIP_ILK_TUSD_A=TUSD-A
+FLIP_MINIMUM_TUSD_A_AUCTION_ID_TO_CHECK=0
+FLIP_TUSD_URL="https://api.coingecko.com/api/v3/simple/price?ids=true-usd&vs_currencies=usd"
+FLIP_TUSD_DISCOUNT=0.25 # e.g. 0.25 = 25% discount from FMV
+
 ###### FLOP Config ######
 FLOP_ACCOUNT_ADDRESS='0x40418bxxxxxx'
 FLOP_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flop.json,pass_file=/opt/keeper/secrets/password-flop.txt'

--- a/flip/tusd-a/flip-tusd-a.sh
+++ b/flip/tusd-a/flip-tusd-a.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+dir="$(dirname "$0")"
+
+source ../env/environment.sh  # Set the RPC host, account address, keys, and everything else
+source ../env/dynamic_gas.sh
+source ${FULL_PATH_TO_KEEPER_DIRECTORY}/_virtualenv/bin/activate # Run virtual environment
+
+# Allows keepers to bid different prices
+MODEL=$1
+
+${FULL_PATH_TO_KEEPER_DIRECTORY}/bin/auction-keeper \
+    --rpc-host ${SERVER_ETH_RPC_HOST:?} \
+    --rpc-timeout 300 \
+    --eth-from ${FLIP_TUSD_A_ACCOUNT_ADDRESS?:} \
+    --eth-key ${FLIP_TUSD_A_ACCOUNT_KEY?:} \
+    --type flip \
+    --max-auctions 100 \
+    $(dynamic_gas_params) \
+    --vat-dai-target ${FLIP_TUSD_A_DAI_IN_VAT} \
+    --from-block ${FIRST_BLOCK_TO_CHECK} \
+    --ilk ${FLIP_ILK_TUSD_A} \
+    --bid-only \
+    --min-auction ${FLIP_MINIMUM_TUSD_A_AUCTION_ID_TO_CHECK} \
+    --model ${dir}/${MODEL}

--- a/flip/tusd-a/model-tusd.sh
+++ b/flip/tusd-a/model-tusd.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# dynamic gas library
+source ../env/dynamic_gas.sh
+
+while true; do
+
+  # share TUSD_URL, DISCOUNT, and GASPRICE_MULTIPLIER
+  source ../env/environment.sh
+
+  # dynamic bid price
+  body=$(curl -s -X GET "$FLIP_TUSD_URL" -H "accept: application/json")
+  tusdPrice=$(echo $body | jq '."true-usd".usd')
+  bidPrice=$(bc -l <<< "$tusdPrice * (1-$FLIP_TUSD_DISCOUNT)")
+
+  echo "{\"price\": \"${bidPrice}\", \"gasPrice\": \"$(dynamic_gas)\"}"
+
+  sleep 25
+done


### PR DESCRIPTION
This commit adds the `TUSD-A` collateral for auction.  Even though this collateral does not have liquidations turned on, this commit should allow keepers to prepare.

DO NOT merge unless the following happens:
- [x] weekly executive for `2020-05-29` is passes
- [x] https://github.com/makerdao/pymaker/pull/173 is merged
- [x] the `auction-keeper` is upgraded with the new `pymaker`