### PR TITLE
SC-7253: Added BAL and YFI. Updates for auction-keeper.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,20 +26,161 @@ After following the setup procedure below, this keeper works out of the box unde
 - Looks for Vaults (i.e. `urns`) at a supplied block height - we recommend starting at the block that `Vat` was deployed:
   - `mainnet` - 8928152
   - `kovan 1.0.2` - 14764534
-- Uses a pricing model that tracks the price of ETH | BAT | USDC | WBTC | TUSD | KNC | ZRX | MANA | USDT | PAXUSD | COMP | LINK | LRC via a public API and applies a `DISCOUNT` before participating
-- All logs from the keeper are saved and appended to a single file (`auction-keeper-flip-ETH-A.log` or or `auction-keeper-flip-ETH-B.log` or `auction-keeper-flip-BAT-A.log` or `auction-keeper-flip-USDC-A.log` or `auction-keeper-flip-USDC-B.log` or `auction-keeper-flip-WBTC-A.log`  or `auction-keeper-flip-TUSD-A.log` or `auction-keeper-flip-KNC-A.log` or `auction-keeper-flip-ZRX-A.log` or `auction-keeper-flip-MANA-A.log` or `auction-keeper-flip-USDT-A.log` or `auction-keeper-flip-PAXUSD-A.log` or `auction-keeper-flip-COMP-A.log` or `auction-keeper-flip-LINK-A.log` or `auction-keeper-flip-LRC-A.log`) 
-- Place unlocked keystore and password file for account address under `secrets` directory. The names of the keystore and password files will need to be updated in the `FLIP_ETH_A_ACCOUNT_KEY` | `FLIP_BAT_A_ACCOUNT_KEY` | `FLIP_USDC_A_ACCOUNT_KEY` | `FLIP_USDC_B_ACCOUNT_KEY` | `FLIP_WBTC_A_ACCOUNT_KEY` | `FLIP_TUSD_A_ACCOUNT_KEY` | `FLIP_KNC_A_ACCOUNT_KEY` | `FLIP_ZRX_A_ACCOUNT_KEY` | `FLIP_MANA_A_ACCOUNT_KEY` | `FLIP_USDT_A_ACCOUNT_KEY` | `FLIP_PAXUSD_A_ACCOUNT_KEY` | `FLIP_COMP_A_ACCOUNT_KEY` | `FLIP_LINK_A_ACCOUNT_KEY` | `FLIP_LRC_A_ACCOUNT_KEY` in the env.
+- Uses a pricing model that tracks the price of the following assets via a public API and applies a `DISCOUNT` before participating:
+    - ETH
+    - BAT
+    - USDC
+    - WBTC
+    - TUSD
+    - KNC
+    - ZRX
+    - MANA
+    - USDT
+    - PAXUSD
+    - COMP
+    - LINK
+    - LRC
+    - BAL
+    - YFI
+- All logs from the keeper are saved and appended to a single file:
+    - `auction-keeper-flip-ETH-A.log`
+    - `auction-keeper-flip-ETH-B.log`
+    - `auction-keeper-flip-BAT-A.log`
+    - `auction-keeper-flip-USDC-A.log`
+    - `auction-keeper-flip-USDC-B.log`
+    - `auction-keeper-flip-WBTC-A.log`
+    - `auction-keeper-flip-TUSD-A.log`
+    - `auction-keeper-flip-KNC-A.log`
+    - `auction-keeper-flip-ZRX-A.log`
+    - `auction-keeper-flip-MANA-A.log`
+    - `auction-keeper-flip-USDT-A.log`
+    - `auction-keeper-flip-PAXUSD-A.log`
+    - `auction-keeper-flip-COMP-A.log`
+    - `auction-keeper-flip-LINK-A.log`
+    - `auction-keeper-flip-LRC-A.log`
+    - `auction-keeper-flip-BAL-A.log`
+    - `auction-keeper-flip-YFI-A.log`
+- Place unlocked keystore and password file for account address under `secrets` directory. The names of the keystore and password files will need to be updated in the environment:
+    - `FLIP_ETH_A_ACCOUNT_KEY`
+    - `FLIP_ETH_B_ACCOUNT_KEY`
+    - `FLIP_BAT_A_ACCOUNT_KEY`
+    - `FLIP_USDC_A_ACCOUNT_KEY`
+    - `FLIP_USDC_B_ACCOUNT_KEY`
+    - `FLIP_WBTC_A_ACCOUNT_KEY`
+    - `FLIP_TUSD_A_ACCOUNT_KEY`
+    - `FLIP_KNC_A_ACCOUNT_KEY`
+    - `FLIP_ZRX_A_ACCOUNT_KEY`
+    - `FLIP_MANA_A_ACCOUNT_KEY`
+    - `FLIP_USDT_A_ACCOUNT_KEY`
+    - `FLIP_PAXUSD_A_ACCOUNT_KEY`
+    - `FLIP_COMP_A_ACCOUNT_KEY`
+    - `FLIP_LINK_A_ACCOUNT_KEY`
+    - `FLIP_LRC_A_ACCOUNT_KEY`
+    - `FLIP_BAL_A_ACCOUNT_KEY`
+    - `FLIP_YFI_A_ACCOUNT_KEY`
 - Configure following variables in `env/environment.sh` file:
     - `SERVER_ETH_RPC_HOST`: URL to ETH Parity node (containing port if case) e.g. http://localhost:8545
     - `ETHGASSTATION_API_KEY`: eth gas station API KEY, can be applied for at https://data.concourseopen.com/
+    - `ETHERSCAN_API_KEY`: etherscan API KEY, can be applied for at https://etherscan.io/myapikey
     - `GASPRICE_MULTIPLIER`: dynamic gas multiplier (e.g. if 2.0 then will use 2 * base)
     - `FIRST_BLOCK_TO_CHECK`: Recommendation under introduction section
-    - `FLIP_ETH_A_ACCOUNT_ADDRESS` | `FLIP_ETH_B_ACCOUNT_ADDRESS` | `FLIP_BAT_A_ACCOUNT_ADDRESS` | `FLIP_USDC_A_ACCOUNT_ADDRESS` | `FLIP_USDC_B_ACCOUNT_ADDRESS` | `FLIP_WBTC_A_ACCOUNT_ADDRESS` | `FLIP_TUSD_A_ACCOUNT_ADDRESS` | `FLIP_KNC_A_ACCOUNT_ADDRESS` | `FLIP_ZRX_A_ACCOUNT_ADDRESS` | `FLIP_MANA_A_ACCOUNT_ADDRESS` | `FLIP_USDT_A_ACCOUNT_ADDRESS` | `FLIP_PAXUSD_A_ACCOUNT_ADDRESS` | `FLIP_COMP_A_ACCOUNT_ADDRESS` | `FLIP_LINK_A_ACCOUNT_ADDRESS` | `FLIP_LRC_A_ACCOUNT_ADDRESS`: address to use for bidding
-    - `FLIP_ETH_A_ACCOUNT_KEY` | `FLIP_ETH_B_ACCOUNT_KEY` | `FLIP_BAT_A_ACCOUNT_KEY` | `FLIP_USDC_A_ACCOUNT_KEY` | `FLIP_USDC_B_ACCOUNT_KEY` | `FLIP_WBTC_A_ACCOUNT_KEY` | `FLIP_TUSD_A_ACCOUNT_KEY` | `FLIP_KNC_A_ACCOUNT_KEY` | `FLIP_ZRX_A_ACCOUNT_KEY` | `FLIP_MANA_A_ACCOUNT_KEY` | `FLIP_USDT_A_ACCOUNT_KEY` | `FLIP_PAXUSD_A_ACCOUNT_KEY` | `FLIP_COMP_A_ACCOUNT_KEY` | `FLIP_LINK_A_ACCOUNT_KEY` | `FLIP_LRC_A_ACCOUNT_KEY`: account key format of `key_file=/opt/keeper/secrets/keystore.json,pass_file=/opt/keeper/secrets/password.txt`  
-    
-    **Note**: path to file should always be `/opt/keeper/secrets/` followed by the name of file you create under secrets directory
-    Ex: if you put `keystore-flip-a.json` and `password-flip-a.txt` under `secrets` directory then var should be configured as
+        - `FLIP_DAI_IN_VAT`: Amount of Dai in Vat (Internal Dai Balance); important that this is higher than your largest estimated bid amount
+    - Amount of Dai in Vat per collateral type:
+        - `FLIP_ETH_A_DAI_IN_VAT`
+        - `FLIP_ETH_B_DAI_IN_VAT`
+        - `FLIP_BAT_A_DAI_IN_VAT`
+        - `FLIP_USDC_A_DAI_IN_VAT`
+        - `FLIP_USDC_B_DAI_IN_VAT`
+        - `FLIP_WBTC_A_DAI_IN_VAT`
+        - `FLIP_TUSD_A_DAI_IN_VAT`
+        - `FLIP_KNC_A_DAI_IN_VAT`
+        - `FLIP_ZRX_A_DAI_IN_VAT`
+        - `FLIP_MANA_A_DAI_IN_VAT`
+        - `FLIP_USDT_A_DAI_IN_VAT`
+        - `FLIP_PAXUSD_A_DAI_IN_VAT`
+        - `FLIP_COMP_A_DAI_IN_VAT`
+        - `FLIP_LINK_A_DAI_IN_VAT`
+        - `FLIP_LRC_A_DAI_IN_VAT`
+        - `FLIP_BAL_A_DAI_IN_VAT`
+        - `FLIP_YFI_A_DAI_IN_VAT`
+    - Minimum auction id to check as recommendation under introduction section:
+        - `FLIP_MINIMUM_ETH_A_AUCTION_ID_TO_CHECK`
+        - `FLIP_MINIMUM_ETH_B_AUCTION_ID_TO_CHECK`
+        - `FLIP_MINIMUM_BAT_A_AUCTION_ID_TO_CHECK`
+        - `FLIP_MINIMUM_USDC_A_AUCTION_ID_TO_CHECK`
+        - `FLIP_MINIMUM_USDC_B_AUCTION_ID_TO_CHECK`
+        - `FLIP_MINIMUM_WBTC_A_AUCTION_ID_TO_CHECK`
+        - `FLIP_MINIMUM_TUSD_A_AUCTION_ID_TO_CHECK`
+        - `FLIP_MINIMUM_KNC_A_AUCTION_ID_TO_CHECK`
+        - `FLIP_MINIMUM_ZRX_A_AUCTION_ID_TO_CHECK`
+        - `FLIP_MINIMUM_MANA_A_AUCTION_ID_TO_CHECK`
+        - `FLIP_MINIMUM_USDT_A_AUCTION_ID_TO_CHECK`
+        - `FLIP_MINIMUM_PAXUSD_A_AUCTION_ID_TO_CHECK`
+        - `FLIP_MINIMUM_COMP_A_AUCTION_ID_TO_CHECK`
+        - `FLIP_MINIMUM_LINK_A_AUCTION_ID_TO_CHECK`
+        - `FLIP_MINIMUM_LRC_A_AUCTION_ID_TO_CHECK`
+        - `FLIP_MINIMUM_BAL_A_AUCTION_ID_TO_CHECK`
+        - `FLIP_MINIMUM_YFI_A_AUCTION_ID_TO_CHECK`
+    - Discount from asset's fair market value (FMV), which will be used as the bid price:
+        - `FLIP_ETH_A_DISCOUNT`
+        - `FLIP_ETH_B_DISCOUNT`
+        - `FLIP_BAT_A_DISCOUNT`
+        - `FLIP_USDC_A_DISCOUNT`
+        - `FLIP_USDC_B_DISCOUNT`
+        - `FLIP_WBTC_A_DISCOUNT`
+        - `FLIP_TUSD_A_DISCOUNT`
+        - `FLIP_KNC_A_DISCOUNT`
+        - `FLIP_ZRX_A_DISCOUNT`
+        - `FLIP_MANA_A_DISCOUNT`
+        - `FLIP_USDT_A_DISCOUNT`
+        - `FLIP_PAXUSD_A_DISCOUNT`
+        - `FLIP_COMP_A_DISCOUNT`
+        - `FLIP_LINK_A_DISCOUNT`
+        - `FLIP_LRC_A_DISCOUNT`
+        - `FLIP_BAL_A_DISCOUNT`
+        - `FLIP_YFI_A_DISCOUNT`
+    - Account address to use for bidding:
+        - `FLIP_ETH_A_ACCOUNT_ADDRESS`
+        - `FLIP_ETH_B_ACCOUNT_ADDRESS`
+        - `FLIP_BAT_A_ACCOUNT_ADDRESS`
+        - `FLIP_USDC_A_ACCOUNT_ADDRESS`
+        - `FLIP_USDC_B_ACCOUNT_ADDRESS`
+        - `FLIP_WBTC_A_ACCOUNT_ADDRESS`
+        - `FLIP_TUSD_A_ACCOUNT_ADDRESS`
+        - `FLIP_KNC_A_ACCOUNT_ADDRESS`
+        - `FLIP_ZRX_A_ACCOUNT_ADDRESS`
+        - `FLIP_MANA_A_ACCOUNT_ADDRESS`
+        - `FLIP_USDT_A_ACCOUNT_ADDRESS`
+        - `FLIP_PAXUSD_A_ACCOUNT_ADDRESS`
+        - `FLIP_COMP_A_ACCOUNT_ADDRESS`
+        - `FLIP_LINK_A_ACCOUNT_ADDRESS`
+        - `FLIP_LRC_A_ACCOUNT_ADDRESS`
+        - `FLIP_BAL_A_ACCOUNT_ADDRESS`
+        - `FLIP_YFI_A_ACCOUNT_ADDRESS`
+    - Account key format of: `key_file=/opt/keeper/secrets/keystore.json,pass_file=/opt/keeper/secrets/password.txt`
+        - `FLIP_ETH_A_ACCOUNT_KEY`
+        - `FLIP_ETH_B_ACCOUNT_KEY`
+        - `FLIP_BAT_A_ACCOUNT_KEY`
+        - `FLIP_USDC_A_ACCOUNT_KEY`
+        - `FLIP_USDC_B_ACCOUNT_KEY`
+        - `FLIP_WBTC_A_ACCOUNT_KEY`
+        - `FLIP_TUSD_A_ACCOUNT_KEY`
+        - `FLIP_KNC_A_ACCOUNT_KEY`
+        - `FLIP_ZRX_A_ACCOUNT_KEY`
+        - `FLIP_MANA_A_ACCOUNT_KEY`
+        - `FLIP_USDT_A_ACCOUNT_KEY`
+        - `FLIP_PAXUSD_A_ACCOUNT_KEY`
+        - `FLIP_COMP_A_ACCOUNT_KEY`
+        - `FLIP_LINK_A_ACCOUNT_KEY`
+        - `FLIP_LRC_A_ACCOUNT_KEY`
+        - `FLIP_BAL_A_ACCOUNT_KEY`
+        - `FLIP_YFI_A_ACCOUNT_KEY`
+
+    **Note**: Path to file should always be `/opt/keeper/secrets/` followed by the name of file you create under secrets directory.
+    Ex: if you put `keystore-flip-a.json` and `password-flip-a.txt` under `secrets` directory then var should be configured as:
     `FLIP_ETH_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-eth-a.json,pass_file=/opt/keeper/secrets/password-flip-eth-a.txt'`
+    or
+    `FLIP_ETH_B_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-eth-b.json,pass_file=/opt/keeper/secrets/password-flip-eth-b.txt'`
     or
     `FLIP_BAT_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-bat-a.json,pass_file=/opt/keeper/secrets/password-flip-bat-a.txt'`
     or
@@ -67,13 +208,12 @@ After following the setup procedure below, this keeper works out of the box unde
     or
     `FLIP_LRC_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-lrc-a.json,pass_file=/opt/keeper/secrets/password-flip-lrc-a.txt'`
     or
-    `FLIP_ETH_B_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-eth-b.json,pass_file=/opt/keeper/secrets/password-flip-eth-b.txt'`  
-    
+    `FLIP_BAL_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-bal-a.json,pass_file=/opt/keeper/secrets/password-flip-bal-a.txt'`
+    or
+    `FLIP_YFI_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-yfi-a.json,pass_file=/opt/keeper/secrets/password-flip-yfi-a.txt'`
+
     **Note**: for better security you should avoid distributing password file to the machine and instead specify only keystore in key variable, e.g. `FLIP_ETH_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-eth-a.json'` and use `./start-interactive-keeper.sh`. You wil be asked to input password on keeper startup.
-    - `FLIP_DAI_IN_VAT`: Amount of Dai in Vat (Internal Dai Balance); important that this is higher than your largest estimated bid amount
-    - `FLIP_ETH_A_DAI_IN_VAT` | `FLIP_ETH_B_DAI_IN_VAT` | `FLIP_BAT_A_DAI_IN_VAT` | `FLIP_USDC_A_DAI_IN_VAT` | `FLIP_USDC_B_DAI_IN_VAT` | `FLIP_WBTC_A_DAI_IN_VAT` | `FLIP_TUSD_A_DAI_IN_VAT` | `FLIP_KNC_A_DAI_IN_VAT` | `FLIP_ZRX_A_DAI_IN_VAT` | `FLIP_MANA_A_DAI_IN_VAT` | `FLIP_USDT_A_DAI_IN_VAT` | `FLIP_PAXUSD_A_DAI_IN_VAT`: Amount of Dai in Vat per collateral type
-    - `FLIP_MINIMUM_ETH_A_AUCTION_ID_TO_CHECK` | `FLIP_MINIMUM_ETH_B_AUCTION_ID_TO_CHECK` | `FLIP_MINIMUM_BAT_A_AUCTION_ID_TO_CHECK` | `FLIP_MINIMUM_USDC_A_AUCTION_ID_TO_CHECK` | `FLIP_MINIMUM_USDC_B_AUCTION_ID_TO_CHECK` | `FLIP_MINIMUM_WBTC_A_AUCTION_ID_TO_CHECK` | `FLIP_MINIMUM_TUSD_A_AUCTION_ID_TO_CHECK` | `FLIP_MINIMUM_KNC_A_AUCTION_ID_TO_CHECK` | `FLIP_MINIMUM_ZRX_A_AUCTION_ID_TO_CHECK` | `FLIP_MINIMUM_MANA_A_AUCTION_ID_TO_CHECK` | `FLIP_MINIMUM_USDT_A_AUCTION_ID_TO_CHECK`: Recommendation under introduction section
-    - `FLIP_ETH_DISCOUNT` | `FLIP_ETH_B_DISCOUNT` | `FLIP_BAT_A_DISCOUNT` | `FLIP_USDC_A_DISCOUNT` | `FLIP_USDC_A_DISCOUNT` | `FLIP_WBTC_A_DISCOUNT` | `FLIP_TUSD_A_DISCOUNT` | `FLIP_KNC_A_DISCOUNT` | `FLIP_ZRX_A_DISCOUNT` | `FLIP_MANA_A_DISCOUNT` | `FLIP_USDT_A_DISCOUNT` | `FLIP_PAXUSD_A_DISCOUNT`: Discount from ETH's or BAT's or USDC's FMV or WBTC's FMV, which will be used as the bid price
+
 
 ### Setup flap keeper
 
@@ -81,10 +221,11 @@ After following the setup procedure below, this keeper works out of the box unde
 - Configure following variables in `env/environment.sh` file:
     - `SERVER_ETH_RPC_HOST`: URL to ETH Parity node (containing port if case) e.g. http://localhost:8545
     - `ETHGASSTATION_API_KEY`: eth gas station API KEY, can be applied for at https://data.concourseopen.com/
+    - `ETHERSCAN_API_KEY`: etherscan API KEY, can be applied for at https://etherscan.io/myapikey
     - `GASPRICE_MULTIPLIER`: dynamic gas multiplier (e.g. if 2.0 then will use 2 * base)
     - `FLAP_ACCOUNT_ADDRESS`: address to use for bidding
-    - `FLAP_ACCOUNT_KEY`: account key format of `key_file=/opt/keeper/secrets/keystore.json,pass_file=/opt/keeper/secrets/password.txt`  
-    
+    - `FLAP_ACCOUNT_KEY`: account key format of `key_file=/opt/keeper/secrets/keystore.json,pass_file=/opt/keeper/secrets/password.txt`
+
     **Note**: path to file should always be `/opt/keeper/secrets/` followed by the name of file you create under secrets directory
     Ex: if you put `keystore-flap.json` and `password-flap.txt` under `secrets` directory then var should be configured as
     `FLAP_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flap.json,pass_file=/opt/keeper/secrets/password-flap.txt'`
@@ -97,11 +238,12 @@ After following the setup procedure below, this keeper works out of the box unde
 - Configure following variables in `env/environment.sh` file:
     - `SERVER_ETH_RPC_HOST`: URL to ETH Parity node (containing port if case) e.g. http://localhost:8545
     - `ETHGASSTATION_API_KEY`: eth gas station API KEY, can be applied for at https://data.concourseopen.com/
+    - `ETHERSCAN_API_KEY`: etherscan API KEY, can be applied for at https://etherscan.io/myapikey
     - `GASPRICE_MULTIPLIER`: dynamic gas multiplier (e.g. if 2.0 then will use 2 * base)
     - `FIRST_BLOCK_TO_CHECK`: Recommendation under introduction section
     - `FLOP_ACCOUNT_ADDRESS`: address to use for bidding
-    - `FLOP_ACCOUNT_KEY`: account key format of `key_file=/opt/keeper/secrets/keystore.json,pass_file=/opt/keeper/secrets/password.txt`  
-    
+    - `FLOP_ACCOUNT_KEY`: account key format of `key_file=/opt/keeper/secrets/keystore.json,pass_file=/opt/keeper/secrets/password.txt`
+
     **Note**: path to file should always be `/opt/keeper/secrets/` followed by the name of file you create under secrets directory
     Ex: if you put `keystore-flop.json` and `password-flop.txt` under `secrets` directory then var should be configured as
     `FLOP_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flop.json,pass_file=/opt/keeper/secrets/password-flop.txt'`
@@ -155,6 +297,12 @@ flip-link-a keeper
 flip-lrc-a keeper
 `./start-keeper.sh flip-lrc-a | tee -a -i auction-keeper-flip-LRC-A.log`
 
+flip-bal-a keeper
+`./start-keeper.sh flip-bal-a | tee -a -i auction-keeper-flip-BAL-A.log`
+
+flip-yfi-a keeper
+`./start-keeper.sh flip-yfi-a | tee -a -i auction-keeper-flip-YFI-A.log`
+
 flap keeper
 `./start-keeper.sh flap | tee -a -i auction-keeper-flap.log`
 
@@ -176,6 +324,9 @@ flip-bat-a keeper
 
 flip-usdc-a keeper
 `./stop-keeper.sh flip-usdc-a`
+
+flip-usdc-a keeper
+`./stop-keeper.sh flip-usdc-b`
 
 flip-wbtc-a keeper
 `./stop-keeper.sh flip-wbtc-a`
@@ -207,6 +358,12 @@ flip-link-a keeper
 flip-lrc-a keeper
 `./stop-keeper.sh flip-lrc-a`
 
+flip-bal-a keeper
+`./stop-keeper.sh flip-bal-a`
+
+flip-yfi-a keeper
+`./stop-keeper.sh flip-yfi-a`
+
 flap keeper
 `./stop-keeper.sh flap`
 
@@ -217,29 +374,26 @@ flop keeper
 
 - configure following variables in `env/environment.sh` file:
 ```
-# Dynamic Gas Price Model
-# 0 = get the gas price from the node (default)
-# 1 = get the gas price from ethgasstation.info
-#     must set ETHGASSTATION_API_KEY
-# 2 = get the gas price from etherchain.org
-# 3 = get the gas price from poanetwork
-#     set POANETWORK_URL env var to point to a self hosted server e.g. POANETWORK_URL=http://localhost:8000
-GAS_MODE=0
-# increase this if you want to use higher price than the one reported
-# (e.g. if 2.0 then will use 2 * fastest)
-GASPRICE_MULTIPLIER=1.4
-# ETHGASSTATION_API_KEY is optional.  If you fill it in the model will use
-# ethgasstation.info for dynamic gas, otherwise we will simply check the node.
-ETHGASSTATION_API_KEY=MY_ETH_GASSTATION_KEY
-```  
-**Note**: this configuration determines keeper gas price strategy as explained in https://github.com/makerdao/auction-keeper#gas-price-strategy 
+# Increase this if you want to use higher price than the one reported
+# (e.g. if 2.0 then will use 2 * fast)
+GASPRICE_MULTIPLIER=1.3
+
+# ETHGASSTATION_API_KEY is optional.  If you fill it in the auction-keeper
+# will use ethgasstation.info for dynamic gas.  Uncomment the line below
+# and supply your API key if you wish to use dynamic gas.
+#
+# ETHGASSTATION_API_KEY=MY_ETH_GASSTATION_KEY
+
+# ETHERSCAN_API_KEY is optional.  If you fill it in the auction-keeper         # will use etherscan API for dynamic gas.  Uncomment the line below            # and supply your API key if you wish to use dynamic gas.                      #                                                                              # ETHERSCAN_API_KEY=MY_ETHERSCAN_API_KEY
+```
+**Note**: this configuration determines keeper gas price strategy as explained in https://github.com/makerdao/auction-keeper#gas-price-strategy
 
 ### Optional additions
 
 Other auction keepers can be added in `docker-compose.yml`.
 
 ### Note on using Windows Subsystem for Linux
-As Docker Desktop is not able to access the filesystem of WSL, you need to copy `dockerized-aution-keeper` somewhere in the `/c/` path and run it from there. e.g. `/c/Users/username/dev/dockerized-auction-keeper` instead of `/home/username/dev/dockerized-auction-keeper`. 
+As Docker Desktop is not able to access the filesystem of WSL, you need to copy `dockerized-aution-keeper` somewhere in the `/c/` path and run it from there. e.g. `/c/Users/username/dev/dockerized-auction-keeper` instead of `/home/username/dev/dockerized-auction-keeper`.
 
 Running `./start-keeper.sh flip-eth-a` from a WSL path will generate this error:
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,21 @@ services:
         max-size: "100m"
         max-file: "10"
     command: ./flip-eth-a.sh model-eth.sh
+  flip-eth-b:
+    build: .
+    image: makerdao/auction-keeper
+    container_name: flip-eth-b
+    working_dir: /opt/keeper/flip-eth-b/
+    volumes:
+      - $PWD/secrets:/opt/keeper/secrets
+      - $PWD/env/:/opt/keeper/env/
+      - $PWD/flip/eth-b/:/opt/keeper/flip-eth-b/
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100m"
+        max-file: "10"
+    command: ./flip-eth-b.sh model-eth.sh
   flip-bat-a:
     build: .
     image: makerdao/auction-keeper
@@ -210,21 +225,36 @@ services:
         max-size: "100m"
         max-file: "10"
     command: ./flip-lrc-a.sh model-lrc.sh
-  flip-eth-b:
+  flip-bal-a:
     build: .
     image: makerdao/auction-keeper
-    container_name: flip-eth-b
-    working_dir: /opt/keeper/flip-eth-b/
+    container_name: flip-bal-a
+    working_dir: /opt/keeper/flip-bal-a/
     volumes:
       - $PWD/secrets:/opt/keeper/secrets
       - $PWD/env/:/opt/keeper/env/
-      - $PWD/flip/eth-b/:/opt/keeper/flip-eth-b/
+      - $PWD/flip/bal-a/:/opt/keeper/flip-bal-a/
     logging:
       driver: "json-file"
       options:
         max-size: "100m"
         max-file: "10"
-    command: ./flip-eth-b.sh model-eth.sh
+    command: ./flip-bal-a.sh model-bal.sh
+  flip-yfi-a:
+    build: .
+    image: makerdao/auction-keeper
+    container_name: flip-yfi-a
+    working_dir: /opt/keeper/flip-yfi-a/
+    volumes:
+      - $PWD/secrets:/opt/keeper/secrets
+      - $PWD/env/:/opt/keeper/env/
+      - $PWD/flip/yfi-a/:/opt/keeper/flip-yfi-a/
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100m"
+        max-file: "10"
+    command: ./flip-yfi-a.sh model-yfi.sh
   flap:
     build: .
     image: makerdao/auction-keeper

--- a/env/dynamic_gas.sh
+++ b/env/dynamic_gas.sh
@@ -1,54 +1,13 @@
-dynamic_gas()
-{
-  SCALE_GWEI=1000000000
-  ETHGASSTATION_URL=https://ethgasstation.info/json/ethgasAPI.json?api-key=$ETHGASSTATION_API_KEY
-  ETHERCHAIN_URL=https://www.etherchain.org/api/gasPriceOracle
-
-  if [[ $GAS_MODE = 1 ]]; then
-    res=$(curl -s -X GET \
-      -H "accept: application/json" \
-      "$ETHGASSTATION_URL" \
-      | jq '.fastest' \
-    )
-    gas=$(bc <<< "(${res}/10) * ${SCALE_GWEI}")
-  elif [[ $GAS_MODE = 2 ]]; then
-    res=$(curl -s -X GET \
-      -H "accept: application/json" \
-      "$ETHERCHAIN_URL" \
-      | jq '.fastest' \
-      | bc -l
-    )
-    gas=$(bc <<< "${res} * ${SCALE_GWEI}")
-  elif [[ $GAS_MODE = 3 ]]; then
-    res=$(curl -s -X GET \
-      -H "accept: application/json" \
-      "${POANETWORK_URL:-https://gasprice.poa.network}" \
-      | jq '.instant' \
-      | bc -l
-    )
-    gas=$(bc <<< "${res} * ${SCALE_GWEI}")
-  else
-    res=$(curl -s -X POST \
-      -H "Content-Type: application/json" \
-      --data "{\"jsonrpc\":\"2.0\",\"method\":\"eth_gasPrice\",\"params\":[],\"id\":${RANDOM}}" \
-      ${SERVER_ETH_RPC_HOST} \
-      | jq -r '.result' \
-      | sed 's/0x//' \
-    )
-    gas=$(bc <<<"ibase=16; $(tr a-f A-F <<<"${res}")")
-  fi
-
-  echo $(bc -l <<< "scale=0; (${gas} * $GASPRICE_MULTIPLIER)/1")
-}
+#!/bin/bash
 
 dynamic_gas_params()
 {
-  if [[ $GAS_MODE = 1 ]]; then
-    echo "--gas-initial-multiplier=${GASPRICE_MULTIPLIER} --ethgasstation-api-key=${ETHGASSTATION_API_KEY}"
-  elif [[ $GAS_MODE = 2 ]]; then
-    echo "--gas-initial-multiplier=${GASPRICE_MULTIPLIER} --etherchain-gas-price"
-  elif [[ $GAS_MODE = 3 ]]; then
-    echo "--gas-initial-multiplier=${GASPRICE_MULTIPLIER} --poanetwork-gas-price --poanetwork-url=${POANETWORK_URL:-https://gasprice.poa.network}"
+  if [ -n "$ETHGASSTATION_API_KEY" ] && [ -n "$ETHERSCAN_API_KEY" ]; then
+    echo "--oracle-gas-price --gas-initial-multiplier=${GASPRICE_MULTIPLIER} --ethgasstation-api-key=${ETHGASSTATION_API_KEY} --etherscan-api-key=${ETHERSCAN_API_KEY}"
+  elif [ -n "$ETHGASSTATION_API_KEY" ]; then
+    echo "--oracle-gas-price --gas-initial-multiplier=${GASPRICE_MULTIPLIER} --ethgasstation-api-key=${ETHGASSTATION_API_KEY}"
+  elif [ -n "$ETHERSCAN_API_KEY" ]; then
+    echo "--oracle-gas-price --gas-initial-multiplier=${GASPRICE_MULTIPLIER} --etherscan-api-key=${ETHERSCAN_API_KEY}"
   else
     echo "--gas-initial-multiplier=${GASPRICE_MULTIPLIER}"
   fi

--- a/env/environment.sh
+++ b/env/environment.sh
@@ -1,20 +1,22 @@
 # host and port
 SERVER_ETH_RPC_HOST=https://localhost:8545
 
-# Dynamic Gas Price Model
-# 0 = get the gas price from the node (default)
-# 1 = get the gas price from ethgasstation.info
-#     must set ETHGASSTATION_API_KEY
-# 2 = get the gas price from etherchain.org
-# 3 = get the gas price from poanetwork
-#     set POANETWORK_URL env var to point to a self hosted server e.g. POANETWORK_URL=http://localhost:8000
-GAS_MODE=0
-# increase this if you want to use higher price than the one reported
+# Increase this if you want to use higher price than the one reported
 # (e.g. if 2.0 then will use 2 * fast)
 GASPRICE_MULTIPLIER=1.3
-# ETHGASSTATION_API_KEY is optional.  If you fill it in the model will use
-# ethgasstation.info for dynamic gas, otherwise we will simply check the node.
-ETHGASSTATION_API_KEY=MY_ETH_GASSTATION_KEY
+
+# ETHGASSTATION_API_KEY is optional.  If you fill it in the auction-keeper
+# will use ethgasstation.info for dynamic gas.  Uncomment the line below
+# and supply your API key if you wish to use dynamic gas.
+#
+# ETHGASSTATION_API_KEY=MY_ETH_GASSTATION_KEY
+
+# ETHERSCAN_API_KEY is optional.  If you fill it in the auction-keeper
+# will use etherscan API for dynamic gas.  Uncomment the line below
+# and supply your API key if you wish to use dynamic gas.
+#
+# ETHERSCAN_API_KEY=MY_ETHERSCAN_API_KEY
+
 FULL_PATH_TO_KEEPER_DIRECTORY=/opt/keeper/auction-keeper
 FIRST_BLOCK_TO_CHECK=8928176
 DAI_IN_VAT=10000
@@ -26,124 +28,7 @@ FLIP_ETH_A_DAI_IN_VAT=${DAI_IN_VAT}
 FLIP_ILK_ETH_A=ETH-A
 FLIP_MINIMUM_ETH_A_AUCTION_ID_TO_CHECK=0
 FLIP_ETH_URL="https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd"
-FLIP_ETH_DISCOUNT=0.25 # e.g. 0.25 = 25% discount from FMV
-
-###### FLIP-BAT-A Config ######
-FLIP_BAT_A_ACCOUNT_ADDRESS='0x40418bxxxxxx'
-FLIP_BAT_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-bat-a.json,pass_file=/opt/keeper/secrets/password-flip-bat-a.txt'
-FLIP_BAT_A_DAI_IN_VAT=${DAI_IN_VAT}
-FLIP_ILK_BAT_A=BAT-A
-FLIP_MINIMUM_BAT_A_AUCTION_ID_TO_CHECK=0
-FLIP_BAT_URL="https://api.coingecko.com/api/v3/simple/price?ids=basic-attention-token&vs_currencies=usd"
-FLIP_BAT_DISCOUNT=0.25 # e.g. 0.25 = 25% discount from FMV
-
-###### FLIP-USDC-A Config ######
-FLIP_USDC_A_ACCOUNT_ADDRESS='0x40418bxxxxxx'
-FLIP_USDC_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-usdc-a.json,pass_file=/opt/keeper/secrets/password-flip-usdc-a.txt'
-FLIP_USDC_A_DAI_IN_VAT=${DAI_IN_VAT}
-FLIP_ILK_USDC_A=USDC-A
-FLIP_MINIMUM_USDC_A_AUCTION_ID_TO_CHECK=0
-FLIP_USDC_URL="https://api.coingecko.com/api/v3/simple/price?ids=usd-coin&vs_currencies=usd"
-FLIP_USDC_DISCOUNT=0.25 # e.g. 0.25 = 25% discount from FMV
-
-###### FLIP-USDC-B Config ######
-FLIP_USDC_B_ACCOUNT_ADDRESS='0x40418bxxxxxx'
-FLIP_USDC_B_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-usdc-b.json,pass_file=/opt/keeper/secrets/password-flip-usdc-b.txt'
-FLIP_USDC_B_DAI_IN_VAT=${DAI_IN_VAT}
-FLIP_ILK_USDC_B=USDC-B
-FLIP_MINIMUM_USDC_B_AUCTION_ID_TO_CHECK=0
-FLIP_USDC_URL="https://api.coingecko.com/api/v3/simple/price?ids=usd-coin&vs_currencies=usd"
-FLIP_USDC_DISCOUNT=0.25 # e.g. 0.25 = 25% discount from FMV
-
-###### FLIP-WBTC-A Config ######
-FLIP_WBTC_A_ACCOUNT_ADDRESS='0x40418bxxxxxx'
-FLIP_WBTC_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-wbtc-a.json,pass_file=/opt/keeper/secrets/password-flip-wbtc-a.txt'
-FLIP_WBTC_A_DAI_IN_VAT=${DAI_IN_VAT}
-FLIP_ILK_WBTC_A=WBTC-A
-FLIP_MINIMUM_WBTC_A_AUCTION_ID_TO_CHECK=0
-FLIP_WBTC_URL="https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd"
-FLIP_WBTC_DISCOUNT=0.25 # e.g. 0.25 = 25% discount from FMV
-
-###### FLIP-TUSD-A Config ######
-FLIP_TUSD_A_ACCOUNT_ADDRESS='0x40418bxxxxxx'
-FLIP_TUSD_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-tusd-a.json,pass_file=/opt/keeper/secrets/password-flip-tusd-a.txt'
-FLIP_TUSD_A_DAI_IN_VAT=${DAI_IN_VAT}
-FLIP_ILK_TUSD_A=TUSD-A
-FLIP_MINIMUM_TUSD_A_AUCTION_ID_TO_CHECK=0
-FLIP_TUSD_URL="https://api.coingecko.com/api/v3/simple/price?ids=true-usd&vs_currencies=usd"
-FLIP_TUSD_DISCOUNT=0.25 # e.g. 0.25 = 25% discount from FMV
-
-###### FLIP-KNC-A Config ######
-FLIP_KNC_A_ACCOUNT_ADDRESS='0x40418bxxxxxx'
-FLIP_KNC_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-knc-a.json,pass_file=/opt/keeper/secrets/password-flip-knc-a.txt'
-FLIP_KNC_A_DAI_IN_VAT=${DAI_IN_VAT}
-FLIP_ILK_KNC_A=KNC-A
-FLIP_MINIMUM_KNC_A_AUCTION_ID_TO_CHECK=0
-FLIP_KNC_URL="https://api.coingecko.com/api/v3/simple/price?ids=kyber-network&vs_currencies=usd"
-FLIP_KNC_DISCOUNT=0.25 # e.g. 0.25 = 25% discount from FMV
-
-###### FLIP-ZRX-A Config ######
-FLIP_ZRX_A_ACCOUNT_ADDRESS='0x40418bxxxxxx'
-FLIP_ZRX_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-zrx-a.json,pass_file=/opt/keeper/secrets/password-flip-zrx-a.txt'
-FLIP_ZRX_A_DAI_IN_VAT=${DAI_IN_VAT}
-FLIP_ILK_ZRX_A=ZRX-A
-FLIP_MINIMUM_ZRX_A_AUCTION_ID_TO_CHECK=0
-FLIP_ZRX_URL="https://api.coingecko.com/api/v3/simple/price?ids=0x&vs_currencies=usd"
-FLIP_ZRX_DISCOUNT=0.25 # e.g. 0.25 = 25% discount from FMV
-
-###### FLIP-MANA-A Config ######
-FLIP_MANA_A_ACCOUNT_ADDRESS='0x40418bxxxxxx'
-FLIP_MANA_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-mana-a.json,pass_file=/opt/keeper/secrets/password-flip-mana-a.txt'
-FLIP_MANA_A_DAI_IN_VAT=${DAI_IN_VAT}
-FLIP_ILK_MANA_A=MANA-A
-FLIP_MINIMUM_MANA_A_AUCTION_ID_TO_CHECK=0
-FLIP_MANA_URL="https://api.coingecko.com/api/v3/simple/price?ids=decentraland&vs_currencies=usd"
-FLIP_MANA_DISCOUNT=0.25 # e.g. 0.25 = 25% discount from FMV
-
-###### FLIP-USDT-A Config ######
-FLIP_USDT_A_ACCOUNT_ADDRESS='0x40418bxxxxxx'
-FLIP_USDT_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-usdt-a.json,pass_file=/opt/keeper/secrets/password-flip-usdt-a.txt'
-FLIP_USDT_A_DAI_IN_VAT=${DAI_IN_VAT}
-FLIP_ILK_USDT_A=USDT-A
-FLIP_MINIMUM_USDT_A_AUCTION_ID_TO_CHECK=0
-FLIP_USDT_URL="https://api.coingecko.com/api/v3/simple/price?ids=tether&vs_currencies=usd"
-FLIP_USDT_DISCOUNT=0.25 # e.g. 0.25 = 25% discount from FMV
-
-###### FLIP-PAXUSD-A Config ######
-FLIP_PAXUSD_A_ACCOUNT_ADDRESS='0x40418bxxxxxx'
-FLIP_PAXUSD_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-paxusd-a.json,pass_file=/opt/keeper/secrets/password-flip-paxusd-a.txt'
-FLIP_PAXUSD_A_DAI_IN_VAT=${DAI_IN_VAT}
-FLIP_ILK_PAXUSD_A=PAXUSD-A
-FLIP_MINIMUM_PAXUSD_A_AUCTION_ID_TO_CHECK=0
-FLIP_PAXUSD_URL="https://api.coingecko.com/api/v3/simple/price?ids=paxos-standard&vs_currencies=usd"
-FLIP_PAXUSD_DISCOUNT=0.25 # e.g. 0.25 = 25% discount from FMV
-
-###### FLIP-COMP-A Config ######
-FLIP_COMP_A_ACCOUNT_ADDRESS='0x40418bxxxxxx'
-FLIP_COMP_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-comp-a.json,pass_file=/opt/keeper/secrets/password-flip-comp-a.txt'
-FLIP_COMP_A_DAI_IN_VAT=${DAI_IN_VAT}
-FLIP_ILK_COMP_A=COMP-A
-FLIP_MINIMUM_COMP_A_AUCTION_ID_TO_CHECK=0
-FLIP_COMP_URL="https://api.coingecko.com/api/v3/simple/price?ids=compound-governance-token&vs_currencies=usd"
-FLIP_COMP_DISCOUNT=0.25 # e.g. 0.25 = 25% discount from FMV
-
-###### FLIP-LINK-A Config ######
-FLIP_LINK_A_ACCOUNT_ADDRESS='0x40418bxxxxxx'
-FLIP_LINK_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-link-a.json,pass_file=/opt/keeper/secrets/password-flip-link-a.txt'
-FLIP_LINK_A_DAI_IN_VAT=${DAI_IN_VAT}
-FLIP_ILK_LINK_A=LINK-A
-FLIP_MINIMUM_LINK_A_AUCTION_ID_TO_CHECK=0
-FLIP_LINK_URL="https://api.coingecko.com/api/v3/simple/price?ids=chainlink&vs_currencies=usd"
-FLIP_LINK_DISCOUNT=0.25 # e.g. 0.25 = 25% discount from FMV
-
-###### FLIP-LRC-A Config ######
-FLIP_LRC_A_ACCOUNT_ADDRESS='0x40418bxxxxxx'
-FLIP_LRC_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-lrc-a.json,pass_file=/opt/keeper/secrets/password-flip-lrc-a.txt'
-FLIP_LRC_A_DAI_IN_VAT=${DAI_IN_VAT}
-FLIP_ILK_LRC_A=LRC-A
-FLIP_MINIMUM_LRC_A_AUCTION_ID_TO_CHECK=0
-FLIP_LRC_URL="https://api.coingecko.com/api/v3/simple/price?ids=loopring&vs_currencies=usd"
-FLIP_LRC_DISCOUNT=0.25 # e.g. 0.25 = 25% discount from FMV
+FLIP_ETH_A_DISCOUNT=0.25 # e.g. 0.25 = 25% discount from FMV
 
 ###### FLIP-ETH-B Config ######
 FLIP_ETH_B_ACCOUNT_ADDRESS='0x40418bxxxxxx'
@@ -152,6 +37,141 @@ FLIP_ETH_B_DAI_IN_VAT=${DAI_IN_VAT}
 FLIP_ILK_ETH_B=ETH-B
 FLIP_MINIMUM_ETH_B_AUCTION_ID_TO_CHECK=0
 FLIP_ETH_B_DISCOUNT=0.25 # e.g. 0.25 = 25% discount from FMV
+
+###### FLIP-BAT-A Config ######
+FLIP_BAT_A_ACCOUNT_ADDRESS='0x40418bxxxxxx'
+FLIP_BAT_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-bat-a.json,pass_file=/opt/keeper/secrets/password-flip-bat-a.txt'
+FLIP_BAT_A_DAI_IN_VAT=${DAI_IN_VAT}
+FLIP_ILK_BAT_A=BAT-A
+FLIP_MINIMUM_BAT_A_AUCTION_ID_TO_CHECK=0
+FLIP_BAT_URL="https://api.coingecko.com/api/v3/simple/price?ids=basic-attention-token&vs_currencies=usd"
+FLIP_BAT_A_DISCOUNT=0.25 # e.g. 0.25 = 25% discount from FMV
+
+###### FLIP-USDC-A Config ######
+FLIP_USDC_A_ACCOUNT_ADDRESS='0x40418bxxxxxx'
+FLIP_USDC_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-usdc-a.json,pass_file=/opt/keeper/secrets/password-flip-usdc-a.txt'
+FLIP_USDC_A_DAI_IN_VAT=${DAI_IN_VAT}
+FLIP_ILK_USDC_A=USDC-A
+FLIP_MINIMUM_USDC_A_AUCTION_ID_TO_CHECK=0
+FLIP_USDC_URL="https://api.coingecko.com/api/v3/simple/price?ids=usd-coin&vs_currencies=usd"
+FLIP_USDC_A_DISCOUNT=0.25 # e.g. 0.25 = 25% discount from FMV
+
+###### FLIP-USDC-B Config ######
+FLIP_USDC_B_ACCOUNT_ADDRESS='0x40418bxxxxxx'
+FLIP_USDC_B_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-usdc-b.json,pass_file=/opt/keeper/secrets/password-flip-usdc-b.txt'
+FLIP_USDC_B_DAI_IN_VAT=${DAI_IN_VAT}
+FLIP_ILK_USDC_B=USDC-B
+FLIP_MINIMUM_USDC_B_AUCTION_ID_TO_CHECK=0
+FLIP_USDC_URL="https://api.coingecko.com/api/v3/simple/price?ids=usd-coin&vs_currencies=usd"
+FLIP_USDC_B_DISCOUNT=0.25 # e.g. 0.25 = 25% discount from FMV
+
+###### FLIP-WBTC-A Config ######
+FLIP_WBTC_A_ACCOUNT_ADDRESS='0x40418bxxxxxx'
+FLIP_WBTC_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-wbtc-a.json,pass_file=/opt/keeper/secrets/password-flip-wbtc-a.txt'
+FLIP_WBTC_A_DAI_IN_VAT=${DAI_IN_VAT}
+FLIP_ILK_WBTC_A=WBTC-A
+FLIP_MINIMUM_WBTC_A_AUCTION_ID_TO_CHECK=0
+FLIP_WBTC_URL="https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd"
+FLIP_WBTC_A_DISCOUNT=0.25 # e.g. 0.25 = 25% discount from FMV
+
+###### FLIP-TUSD-A Config ######
+FLIP_TUSD_A_ACCOUNT_ADDRESS='0x40418bxxxxxx'
+FLIP_TUSD_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-tusd-a.json,pass_file=/opt/keeper/secrets/password-flip-tusd-a.txt'
+FLIP_TUSD_A_DAI_IN_VAT=${DAI_IN_VAT}
+FLIP_ILK_TUSD_A=TUSD-A
+FLIP_MINIMUM_TUSD_A_AUCTION_ID_TO_CHECK=0
+FLIP_TUSD_URL="https://api.coingecko.com/api/v3/simple/price?ids=true-usd&vs_currencies=usd"
+FLIP_TUSD_A_DISCOUNT=0.25 # e.g. 0.25 = 25% discount from FMV
+
+###### FLIP-KNC-A Config ######
+FLIP_KNC_A_ACCOUNT_ADDRESS='0x40418bxxxxxx'
+FLIP_KNC_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-knc-a.json,pass_file=/opt/keeper/secrets/password-flip-knc-a.txt'
+FLIP_KNC_A_DAI_IN_VAT=${DAI_IN_VAT}
+FLIP_ILK_KNC_A=KNC-A
+FLIP_MINIMUM_KNC_A_AUCTION_ID_TO_CHECK=0
+FLIP_KNC_URL="https://api.coingecko.com/api/v3/simple/price?ids=kyber-network&vs_currencies=usd"
+FLIP_KNC_A_DISCOUNT=0.25 # e.g. 0.25 = 25% discount from FMV
+
+###### FLIP-ZRX-A Config ######
+FLIP_ZRX_A_ACCOUNT_ADDRESS='0x40418bxxxxxx'
+FLIP_ZRX_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-zrx-a.json,pass_file=/opt/keeper/secrets/password-flip-zrx-a.txt'
+FLIP_ZRX_A_DAI_IN_VAT=${DAI_IN_VAT}
+FLIP_ILK_ZRX_A=ZRX-A
+FLIP_MINIMUM_ZRX_A_AUCTION_ID_TO_CHECK=0
+FLIP_ZRX_URL="https://api.coingecko.com/api/v3/simple/price?ids=0x&vs_currencies=usd"
+FLIP_ZRX_A_DISCOUNT=0.25 # e.g. 0.25 = 25% discount from FMV
+
+###### FLIP-MANA-A Config ######
+FLIP_MANA_A_ACCOUNT_ADDRESS='0x40418bxxxxxx'
+FLIP_MANA_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-mana-a.json,pass_file=/opt/keeper/secrets/password-flip-mana-a.txt'
+FLIP_MANA_A_DAI_IN_VAT=${DAI_IN_VAT}
+FLIP_ILK_MANA_A=MANA-A
+FLIP_MINIMUM_MANA_A_AUCTION_ID_TO_CHECK=0
+FLIP_MANA_URL="https://api.coingecko.com/api/v3/simple/price?ids=decentraland&vs_currencies=usd"
+FLIP_MANA_A_DISCOUNT=0.25 # e.g. 0.25 = 25% discount from FMV
+
+###### FLIP-USDT-A Config ######
+FLIP_USDT_A_ACCOUNT_ADDRESS='0x40418bxxxxxx'
+FLIP_USDT_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-usdt-a.json,pass_file=/opt/keeper/secrets/password-flip-usdt-a.txt'
+FLIP_USDT_A_DAI_IN_VAT=${DAI_IN_VAT}
+FLIP_ILK_USDT_A=USDT-A
+FLIP_MINIMUM_USDT_A_AUCTION_ID_TO_CHECK=0
+FLIP_USDT_URL="https://api.coingecko.com/api/v3/simple/price?ids=tether&vs_currencies=usd"
+FLIP_USDT_A_DISCOUNT=0.25 # e.g. 0.25 = 25% discount from FMV
+
+###### FLIP-PAXUSD-A Config ######
+FLIP_PAXUSD_A_ACCOUNT_ADDRESS='0x40418bxxxxxx'
+FLIP_PAXUSD_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-paxusd-a.json,pass_file=/opt/keeper/secrets/password-flip-paxusd-a.txt'
+FLIP_PAXUSD_A_DAI_IN_VAT=${DAI_IN_VAT}
+FLIP_ILK_PAXUSD_A=PAXUSD-A
+FLIP_MINIMUM_PAXUSD_A_AUCTION_ID_TO_CHECK=0
+FLIP_PAXUSD_URL="https://api.coingecko.com/api/v3/simple/price?ids=paxos-standard&vs_currencies=usd"
+FLIP_PAXUSD_A_DISCOUNT=0.25 # e.g. 0.25 = 25% discount from FMV
+
+###### FLIP-COMP-A Config ######
+FLIP_COMP_A_ACCOUNT_ADDRESS='0x40418bxxxxxx'
+FLIP_COMP_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-comp-a.json,pass_file=/opt/keeper/secrets/password-flip-comp-a.txt'
+FLIP_COMP_A_DAI_IN_VAT=${DAI_IN_VAT}
+FLIP_ILK_COMP_A=COMP-A
+FLIP_MINIMUM_COMP_A_AUCTION_ID_TO_CHECK=0
+FLIP_COMP_URL="https://api.coingecko.com/api/v3/simple/price?ids=compound-governance-token&vs_currencies=usd"
+FLIP_COMP_A_DISCOUNT=0.25 # e.g. 0.25 = 25% discount from FMV
+
+###### FLIP-LINK-A Config ######
+FLIP_LINK_A_ACCOUNT_ADDRESS='0x40418bxxxxxx'
+FLIP_LINK_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-link-a.json,pass_file=/opt/keeper/secrets/password-flip-link-a.txt'
+FLIP_LINK_A_DAI_IN_VAT=${DAI_IN_VAT}
+FLIP_ILK_LINK_A=LINK-A
+FLIP_MINIMUM_LINK_A_AUCTION_ID_TO_CHECK=0
+FLIP_LINK_URL="https://api.coingecko.com/api/v3/simple/price?ids=chainlink&vs_currencies=usd"
+FLIP_LINK_A_DISCOUNT=0.25 # e.g. 0.25 = 25% discount from FMV
+
+###### FLIP-LRC-A Config ######
+FLIP_LRC_A_ACCOUNT_ADDRESS='0x40418bxxxxxx'
+FLIP_LRC_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-lrc-a.json,pass_file=/opt/keeper/secrets/password-flip-lrc-a.txt'
+FLIP_LRC_A_DAI_IN_VAT=${DAI_IN_VAT}
+FLIP_ILK_LRC_A=LRC-A
+FLIP_MINIMUM_LRC_A_AUCTION_ID_TO_CHECK=0
+FLIP_LRC_URL="https://api.coingecko.com/api/v3/simple/price?ids=loopring&vs_currencies=usd"
+FLIP_LRC_A_DISCOUNT=0.25 # e.g. 0.25 = 25% discount from FMV
+
+###### FLIP-BAL-A Config ######
+FLIP_BAL_A_ACCOUNT_ADDRESS='0x40418bxxxxxx'
+FLIP_BAL_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-bal-a.json,pass_file=/opt/keeper/secrets/password-flip-bal-a.txt'
+FLIP_BAL_A_DAI_IN_VAT=${DAI_IN_VAT}
+FLIP_ILK_BAL_A=BAL-A
+FLIP_MINIMUM_BAL_A_AUCTION_ID_TO_CHECK=0
+FLIP_BAL_URL="https://api.coingecko.com/api/v3/simple/price?ids=balancer&vs_currencies=usd"
+FLIP_BAL_A_DISCOUNT=0.25 # e.g. 0.25 = 25% discount from FMV
+
+###### FLIP-LRC-A Config ######
+FLIP_LRC_A_ACCOUNT_ADDRESS='0x40418bxxxxxx'
+FLIP_YFI_A_ACCOUNT_KEY='key_file=/opt/keeper/secrets/keystore-flip-yfi-a.json,pass_file=/opt/keeper/secrets/password-flip-yfi-a.txt'
+FLIP_YFI_A_DAI_IN_VAT=${DAI_IN_VAT}
+FLIP_ILK_YFI_A=YFI-A
+FLIP_MINIMUM_YFI_A_AUCTION_ID_TO_CHECK=0
+FLIP_YFI_URL="https://api.coingecko.com/api/v3/simple/price?ids=yearn-finance&vs_currencies=usd"
+FLIP_YFI_A_DISCOUNT=0.25 # e.g. 0.25 = 25% discount from FMV
 
 ###### FLAP Config ######
 FLAP_ACCOUNT_ADDRESS='0x40418bxxxxxx'

--- a/flip/bal-a/flip-bal-a.sh
+++ b/flip/bal-a/flip-bal-a.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+dir="$(dirname "$0")"
+
+source ../env/environment.sh  # Set the RPC host, account address, keys, and everything else
+source ../env/dynamic_gas.sh
+source ${FULL_PATH_TO_KEEPER_DIRECTORY}/_virtualenv/bin/activate # Run virtual environment
+
+# Allows keepers to bid different prices
+MODEL=$1
+
+${FULL_PATH_TO_KEEPER_DIRECTORY}/bin/auction-keeper \
+    --rpc-host ${SERVER_ETH_RPC_HOST:?} \
+    --rpc-timeout 300 \
+    --eth-from ${FLIP_BAL_A_ACCOUNT_ADDRESS?:} \
+    --eth-key ${FLIP_BAL_A_ACCOUNT_KEY?:} \
+    --type flip \
+    --max-auctions 100 \
+    $(dynamic_gas_params) \
+    --vat-dai-target ${FLIP_BAL_A_DAI_IN_VAT} \
+    --from-block ${FIRST_BLOCK_TO_CHECK} \
+    --ilk ${FLIP_ILK_BAL_A} \
+    --bid-only \
+    --min-auction ${FLIP_MINIMUM_BAL_A_AUCTION_ID_TO_CHECK} \
+    --model ${dir}/${MODEL}

--- a/flip/bal-a/model-bal.sh
+++ b/flip/bal-a/model-bal.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+while true; do
+
+  source ../env/environment.sh
+
+  # dynamic bid price
+  body=$(curl -s -X GET "$FLIP_BAL_URL" -H "accept: application/json")
+  balPrice=$(echo $body | jq '."balancer".usd')
+  bidPrice=$(bc -l <<< "$balPrice * (1-$FLIP_BAL_A_DISCOUNT)")
+
+  echo "{\"price\": \"${bidPrice}\"}"
+
+  sleep 25
+done

--- a/flip/bat-a/model-bat.sh
+++ b/flip/bat-a/model-bat.sh
@@ -7,7 +7,7 @@ while true; do
   # dynamic bid price
   body=$(curl -s -X GET "$FLIP_BAT_URL" -H "accept: application/json")
   batPrice=$(echo $body | jq '."basic-attention-token".usd')
-  bidPrice=$(bc -l <<< "$batPrice * (1-$FLIP_BAT_DISCOUNT)")
+  bidPrice=$(bc -l <<< "$batPrice * (1-$FLIP_BAT_A_DISCOUNT)")
 
   echo "{\"price\": \"${bidPrice}\"}"
 

--- a/flip/comp-a/model-comp.sh
+++ b/flip/comp-a/model-comp.sh
@@ -7,7 +7,7 @@ while true; do
   # dynamic bid price
   body=$(curl -s -X GET "$FLIP_COMP_URL" -H "accept: application/json")
   compPrice=$(echo $body | jq '."compound-governance-token".usd')
-  bidPrice=$(bc -l <<< "$compPrice * (1-$FLIP_COMP_DISCOUNT)")
+  bidPrice=$(bc -l <<< "$compPrice * (1-$FLIP_COMP_A_DISCOUNT)")
 
   echo "{\"price\": \"${bidPrice}\"}"
 

--- a/flip/eth-a/model-eth.sh
+++ b/flip/eth-a/model-eth.sh
@@ -7,7 +7,7 @@ while true; do
   # dynamic bid price
   body=$(curl -s -X GET "${FLIP_ETH_URL}" -H "accept: application/json")
   ethPrice=$(echo ${body} | jq '.ethereum.usd')
-  bidPrice=$(bc -l <<< "${ethPrice} * (1-${FLIP_ETH_DISCOUNT})")
+  bidPrice=$(bc -l <<< "${ethPrice} * (1-${FLIP_ETH_A_DISCOUNT})")
 
   echo "{\"price\": \"${bidPrice}\"}"
 

--- a/flip/knc-a/model-knc.sh
+++ b/flip/knc-a/model-knc.sh
@@ -7,7 +7,7 @@ while true; do
   # dynamic bid price
   body=$(curl -s -X GET "$FLIP_KNC_URL" -H "accept: application/json")
   kncPrice=$(echo $body | jq '."kyber-network".usd')
-  bidPrice=$(bc -l <<< "$kncPrice * (1-$FLIP_KNC_DISCOUNT)")
+  bidPrice=$(bc -l <<< "$kncPrice * (1-$FLIP_KNC_A_DISCOUNT)")
 
   echo "{\"price\": \"${bidPrice}\"}"
 

--- a/flip/link-a/model-link.sh
+++ b/flip/link-a/model-link.sh
@@ -7,7 +7,7 @@ while true; do
   # dynamic bid price
   body=$(curl -s -X GET "$FLIP_LINK_URL" -H "accept: application/json")
   linkPrice=$(echo $body | jq '."chainlink".usd')
-  bidPrice=$(bc -l <<< "$linkPrice * (1-$FLIP_LINK_DISCOUNT)")
+  bidPrice=$(bc -l <<< "$linkPrice * (1-$FLIP_LINK_A_DISCOUNT)")
 
   echo "{\"price\": \"${bidPrice}\"}"
 

--- a/flip/lrc-a/model-lrc.sh
+++ b/flip/lrc-a/model-lrc.sh
@@ -7,7 +7,7 @@ while true; do
   # dynamic bid price
   body=$(curl -s -X GET "$FLIP_LRC_URL" -H "accept: application/json")
   lrcPrice=$(echo $body | jq '."loopring".usd')
-  bidPrice=$(bc -l <<< "$lrcPrice * (1-$FLIP_LRC_DISCOUNT)")
+  bidPrice=$(bc -l <<< "$lrcPrice * (1-$FLIP_LRC_A_DISCOUNT)")
 
   echo "{\"price\": \"${bidPrice}\"}"
 

--- a/flip/mana-a/model-mana.sh
+++ b/flip/mana-a/model-mana.sh
@@ -7,7 +7,7 @@ while true; do
   # dynamic bid price
   body=$(curl -s -X GET "$FLIP_MANA_URL" -H "accept: application/json")
   manaPrice=$(echo $body | jq '."decentraland".usd')
-  bidPrice=$(bc -l <<< "$manaPrice * (1-$FLIP_MANA_DISCOUNT)")
+  bidPrice=$(bc -l <<< "$manaPrice * (1-$FLIP_MANA_A_DISCOUNT)")
 
   echo "{\"price\": \"${bidPrice}\"}"
 

--- a/flip/paxusd-a/model-paxusd.sh
+++ b/flip/paxusd-a/model-paxusd.sh
@@ -7,7 +7,7 @@ while true; do
   # dynamic bid price
   body=$(curl -s -X GET "$FLIP_PAXUSD_URL" -H "accept: application/json")
   paxusdPrice=$(echo $body | jq '."paxos-standard".usd')
-  bidPrice=$(bc -l <<< "$paxusdPrice * (1-$FLIP_PAXUSD_DISCOUNT)")
+  bidPrice=$(bc -l <<< "$paxusdPrice * (1-$FLIP_PAXUSD_A_DISCOUNT)")
 
   echo "{\"price\": \"${bidPrice}\"}"
 

--- a/flip/tusd-a/model-tusd.sh
+++ b/flip/tusd-a/model-tusd.sh
@@ -7,7 +7,7 @@ while true; do
   # dynamic bid price
   body=$(curl -s -X GET "$FLIP_TUSD_URL" -H "accept: application/json")
   tusdPrice=$(echo $body | jq '."true-usd".usd')
-  bidPrice=$(bc -l <<< "$tusdPrice * (1-$FLIP_TUSD_DISCOUNT)")
+  bidPrice=$(bc -l <<< "$tusdPrice * (1-$FLIP_TUSD_A_DISCOUNT)")
 
   echo "{\"price\": \"${bidPrice}\"}"
 

--- a/flip/usdc-a/model-usdc.sh
+++ b/flip/usdc-a/model-usdc.sh
@@ -7,7 +7,7 @@ while true; do
   # dynamic bid price
   body=$(curl -s -X GET "$FLIP_USDC_URL" -H "accept: application/json")
   usdcPrice=$(echo $body | jq '."usd-coin".usd')
-  bidPrice=$(bc -l <<< "$usdcPrice * (1-$FLIP_USDC_DISCOUNT)")
+  bidPrice=$(bc -l <<< "$usdcPrice * (1-$FLIP_USDC_A_DISCOUNT)")
 
   echo "{\"price\": \"${bidPrice}\"}"
 

--- a/flip/usdc-b/model-usdc.sh
+++ b/flip/usdc-b/model-usdc.sh
@@ -7,7 +7,7 @@ while true; do
   # dynamic bid price
   body=$(curl -s -X GET "$FLIP_USDC_URL" -H "accept: application/json")
   usdcPrice=$(echo $body | jq '."usd-coin".usd')
-  bidPrice=$(bc -l <<< "$usdcPrice * (1-$FLIP_USDC_DISCOUNT)")
+  bidPrice=$(bc -l <<< "$usdcPrice * (1-$FLIP_USDC_B_DISCOUNT)")
 
   echo "{\"price\": \"${bidPrice}\"}"
 

--- a/flip/usdt-a/model-usdt.sh
+++ b/flip/usdt-a/model-usdt.sh
@@ -7,7 +7,7 @@ while true; do
   # dynamic bid price
   body=$(curl -s -X GET "$FLIP_USDT_URL" -H "accept: application/json")
   usdtPrice=$(echo $body | jq '."tether".usd')
-  bidPrice=$(bc -l <<< "$usdtPrice * (1-$FLIP_USDT_DISCOUNT)")
+  bidPrice=$(bc -l <<< "$usdtPrice * (1-$FLIP_USDT_A_DISCOUNT)")
 
   echo "{\"price\": \"${bidPrice}\"}"
 

--- a/flip/wbtc-a/model-wbtc.sh
+++ b/flip/wbtc-a/model-wbtc.sh
@@ -7,7 +7,7 @@ while true; do
   # dynamic bid price
   body=$(curl -s -X GET "${FLIP_WBTC_URL}" -H "accept: application/json")
   bitcoinPrice=$(echo ${body} | jq '.bitcoin.usd')
-  bidPrice=$(bc -l <<< "${bitcoinPrice} * (1-${FLIP_WBTC_DISCOUNT})")
+  bidPrice=$(bc -l <<< "${bitcoinPrice} * (1-${FLIP_WBTC_A_DISCOUNT})")
 
   echo "{\"price\": \"${bidPrice}\"}"
 

--- a/flip/yfi-a/flip-yfi-a.sh
+++ b/flip/yfi-a/flip-yfi-a.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+dir="$(dirname "$0")"
+
+source ../env/environment.sh  # Set the RPC host, account address, keys, and everything else
+source ../env/dynamic_gas.sh
+source ${FULL_PATH_TO_KEEPER_DIRECTORY}/_virtualenv/bin/activate # Run virtual environment
+
+# Allows keepers to bid different prices
+MODEL=$1
+
+${FULL_PATH_TO_KEEPER_DIRECTORY}/bin/auction-keeper \
+    --rpc-host ${SERVER_ETH_RPC_HOST:?} \
+    --rpc-timeout 300 \
+    --eth-from ${FLIP_YFI_A_ACCOUNT_ADDRESS?:} \
+    --eth-key ${FLIP_YFI_A_ACCOUNT_KEY?:} \
+    --type flip \
+    --max-auctions 100 \
+    $(dynamic_gas_params) \
+    --vat-dai-target ${FLIP_YFI_A_DAI_IN_VAT} \
+    --from-block ${FIRST_BLOCK_TO_CHECK} \
+    --ilk ${FLIP_ILK_YFI_A} \
+    --bid-only \
+    --min-auction ${FLIP_MINIMUM_YFI_A_AUCTION_ID_TO_CHECK} \
+    --model ${dir}/${MODEL}

--- a/flip/yfi-a/model-yfi.sh
+++ b/flip/yfi-a/model-yfi.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+while true; do
+
+  source ../env/environment.sh
+
+  # dynamic bid price
+  body=$(curl -s -X GET "$FLIP_YFI_URL" -H "accept: application/json")
+  yfiPrice=$(echo $body | jq '."yearn-finance".usd')
+  bidPrice=$(bc -l <<< "$yfiPrice * (1-$FLIP_YFI_A_DISCOUNT)")
+
+  echo "{\"price\": \"${bidPrice}\"}"
+
+  sleep 25
+done

--- a/flip/zrx-a/model-zrx.sh
+++ b/flip/zrx-a/model-zrx.sh
@@ -7,7 +7,7 @@ while true; do
   # dynamic bid price
   body=$(curl -s -X GET "$FLIP_ZRX_URL" -H "accept: application/json")
   zrxPrice=$(echo $body | jq '."0x".usd')
-  bidPrice=$(bc -l <<< "$zrxPrice * (1-$FLIP_ZRX_DISCOUNT)")
+  bidPrice=$(bc -l <<< "$zrxPrice * (1-$FLIP_ZRX_A_DISCOUNT)")
 
   echo "{\"price\": \"${bidPrice}\"}"
 


### PR DESCRIPTION
- adds `BAL`
- adds `YFI`
- moved `ETH-B` next to `ETH-A`
- fixes a bunch of mistakes in the readme, and makes it easier to update in the future by putting new assets on their own lines.
- removed `dynamic_gas()` function as it's no longer needed
- remove `GAS_MODE` to take advantage of https://github.com/makerdao/auction-keeper/pull/94
- updated files to do what readme mentions around the `FLIP_TOKEN_LETTER_DISCOUNT` variable